### PR TITLE
0640 on freshclam.conf isn't always suitable.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
   template:
     src: freshclam.conf.j2
     dest: "{{ clamav_config_dir }}/freshclam.conf"
-    mode: "0640"
+    mode: "{{ freshclam_mode }}"
 
 - name: create database directory
   file:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -100,3 +100,12 @@ clamav_requirements:
   - checkpolicy
   - policycoreutils-python
   - policycoreutils
+
+_freshclam_mode:
+  Alpine: "0640"
+  Debian: "0444"
+  RedHat: "0640"
+  CentOS: "0640"
+  Suse: "0640"
+
+freshclam_mode: "{{ _freshclam_mode[ansible_distribution] | default(_freshclam_mode[ansible_os_family]) }}"


### PR DESCRIPTION
On a default Debian Buster install if the ownership of freshclam.conf stays the default clamav:adm (which it does, the role makes no ownership changes) the permissions need to stay the default 0444, 0640 causes apparmor to deny the access.

```
[ 5174.959151] audit: type=1400 audit(1609865058.846:17): apparmor="DENIED" operation="capable" profile="/usr/bin/freshclam" pid=27432 comm="freshclam" capability=2  capname="dac_read_search"
[ 5174.959155] audit: type=1400 audit(1609865058.846:18): apparmor="DENIED" operation="capable" profile="/usr/bin/freshclam" pid=27432 comm="freshclam" capability=1  capname="dac_override"
```

Oddly changing the owner to root also makes the mode 0640 work. I'm not going to do that though.