### PR TITLE
Add support for CentOS 8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,6 @@
         - load selinux pp for clamav
   when:
     - ansible_selinux is defined
-    - ansible_selinux | bool
     - ansible_selinux.status == "enabled"
 
 - name: place freshclam.conf

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,9 +12,6 @@ _clamav_packages:
     - clamav-update
   Alpine:
     - clamav-daemon
-  CentOS:
-    - clamav
-    - clamav-update
   RedHat:
     - clamav
     - clamav-scanner
@@ -68,7 +65,6 @@ _clamav_services:
     - clamd@scan
   RedHat:
     - clamd@scan
-  CentOS:
     - clamav-clamonacc
     - clamav-freshclam
   Debian:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,9 @@ _clamav_packages:
     - clamav-update
   Alpine:
     - clamav-daemon
+  CentOS:
+    - clamav
+    - clamav-update
   RedHat:
     - clamav
     - clamav-scanner
@@ -65,6 +68,7 @@ _clamav_services:
     - clamd@scan
   RedHat:
     - clamd@scan
+  CentOS:
     - clamav-clamonacc
     - clamav-freshclam
   Debian:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -69,6 +69,7 @@ _clamav_services:
   RedHat:
     - clamd@scan
   CentOS:
+    - clamav-clamonacc
     - clamav-freshclam
   Debian:
     - clamav-daemon

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -96,10 +96,17 @@ _clamav_group:
 
 clamav_group: "{{ _clamav_group[ansible_distribution] | default(_clamav_group[ansible_os_family]) }}"
 
-clamav_requirements:
-  - checkpolicy
-  - policycoreutils-python
-  - policycoreutils
+clamav_requirements: "{{ _clamav_requirements[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_clamav_requirements[ansible_distribution] | default(_clamav_requirements[ansible_os_family])) | default(_clamav_requirements['default']) }}"
+
+_clamav_requirements:
+  default:
+    - checkpolicy
+    - policycoreutils-python
+    - policycoreutils
+  CentOS_8:
+    - checkpolicy
+    - python3-policycoreutils
+    - policycoreutils
 
 _freshclam_mode:
   Alpine: "0640"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -103,7 +103,7 @@ _clamav_requirements:
     - checkpolicy
     - policycoreutils-python
     - policycoreutils
-  CentOS_8:
+  CentOS-8:
     - checkpolicy
     - python3-policycoreutils
     - policycoreutils

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,6 +15,7 @@ _clamav_packages:
   CentOS:
     - clamav
     - clamav-update
+    - clamav-scanner-systemd
   RedHat:
     - clamav
     - clamav-scanner
@@ -69,6 +70,7 @@ _clamav_services:
   RedHat:
     - clamd@scan
   CentOS:
+    - clamd@scan
     - clamav-clamonacc
     - clamav-freshclam
   Debian:


### PR DESCRIPTION
**Describe the change**
Adds support for CentOS 8 and on access file scanning.

* Adds missing yum package: `clamav-scanner-systemd` to add the `clamd@scan` service.
* Adds `clamd@scan` service to list of services to manage.
* CentOS 8 requires a different `policycoreutils-python`, so this PR adds support for different distribution-requirements.

**Testing**
We deployed our fork towards our servers.
