### PR TITLE
Private Mirror Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ clamav_configuration:
   - line: "LogFile /var/log/clamd.scan"
 ```
 
+### [Playbook Variables](#playbook-variables)
+
+Aside from variables documented in `vars/main.yml` that can be overridden, if you have local clamav mirrors (as recommended by ClamAV), you will also need to define a list variable with your mirrors to add, as the following example indicate.
+
+```
+freshclam_private_mirrors:
+  - mirror1.mynetwork.com
+  - mirror2.mynetwork.com
+```
+
 ## [Requirements](#requirements)
 
 - pip packages listed in [requirements.txt](https://github.com/robertdebock/ansible-role-clamav/blob/master/requirements.txt).

--- a/templates/freshclam.conf.j2
+++ b/templates/freshclam.conf.j2
@@ -108,6 +108,11 @@ DatabaseMirror database.clamav.net
 # Default: disabled
 #PrivateMirror mirror1.mynetwork.com
 #PrivateMirror mirror2.mynetwork.com
+{% if freshclam_private_mirrors is defined %}
+{% for mirror in freshclam_private_mirrors %}
+PrivateMirror {{ mirror }}
+{% endfor %}
+{% endif %}
 
 # Number of database checks per day.
 # Default: 12 (every two hours)


### PR DESCRIPTION
To allow people to use their own local mirrors (Per ClamAV's recommendation), the freshclam template
was updated to add the mirrors to be added if the variable list is defined.

---
name: Pull request
about: Allow people to setup local ClamAV mirrors

---

**Describe the change**
ClamAV [recommends](https://docs.clamav.net/appendix/CvdPrivateMirror.html) using a local mirror instead of using the upstream to relive load on their resources. To allow that, the template is updated to allow a list of mirrors to be added if the list variable is defined.

**Testing**
No tests were added in this PR.
